### PR TITLE
Make project testable without i3

### DIFF
--- a/bar_test.go
+++ b/bar_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestGetBarConfig(t *testing.T) {
-	ipc, _ := GetIPCSocket()
+	ipc := GetTestIPC(testMessages["bar"])
 
 	ids, err := ipc.GetBarIds()
 	if err != nil {

--- a/bar_test.go
+++ b/bar_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestGetBarConfig(t *testing.T) {
-	ipc := GetTestIPC(testMessages["bar"])
+	ipc := getTestIPC(testMessages["bar"])
 
 	ids, err := ipc.GetBarIds()
 	if err != nil {

--- a/bar_test.go
+++ b/bar_test.go
@@ -17,7 +17,9 @@ import (
 )
 
 func TestGetBarConfig(t *testing.T) {
-	ipc := getTestIPC(testMessages["bar"])
+	ipc, _ := GetIPCSocket()
+
+	go startTestIPCSocket(testMessages["bar"])
 
 	ids, err := ipc.GetBarIds()
 	if err != nil {

--- a/command_test.go
+++ b/command_test.go
@@ -17,7 +17,10 @@ import (
 )
 
 func TestCommand(t *testing.T) {
-	ipc := getTestIPC(testMessages["command"])
+	ipc, _ := GetIPCSocket()
+
+	go startTestIPCSocket(testMessages["command"])
+
 	defer ipc.Close()
 
 	// `exec /bin/true` is a good NOP operation for testing

--- a/command_test.go
+++ b/command_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestCommand(t *testing.T) {
-	ipc, _ := GetIPCSocket()
+	ipc := getTestIPC(testMessages["command"])
 	defer ipc.Close()
 
 	// `exec /bin/true` is a good NOP operation for testing

--- a/marks_test.go
+++ b/marks_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestGetMarks(t *testing.T) {
-	ipc, _ := GetIPCSocket()
+	ipc := getTestIPC(testMessages["marks"])
 
 	_, err := ipc.GetMarks()
 	if err != nil {

--- a/marks_test.go
+++ b/marks_test.go
@@ -17,7 +17,9 @@ import (
 )
 
 func TestGetMarks(t *testing.T) {
-	ipc := getTestIPC(testMessages["marks"])
+	ipc, _ := GetIPCSocket()
+
+	go startTestIPCSocket(testMessages["marks"])
 
 	_, err := ipc.GetMarks()
 	if err != nil {

--- a/outputs_test.go
+++ b/outputs_test.go
@@ -17,7 +17,9 @@ import (
 )
 
 func TestGetOutputs(t *testing.T) {
-	ipc := getTestIPC(testMessages["outputs"])
+	ipc, _ := GetIPCSocket()
+
+	go startTestIPCSocket(testMessages["outputs"])
 
 	//outputs, err := GetOutputs(ipc)
 	_, err := ipc.GetOutputs()

--- a/outputs_test.go
+++ b/outputs_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestGetOutputs(t *testing.T) {
-	ipc, _ := GetIPCSocket()
+	ipc := getTestIPC(testMessages["outputs"])
 
 	//outputs, err := GetOutputs(ipc)
 	_, err := ipc.GetOutputs()

--- a/socket_test.go
+++ b/socket_test.go
@@ -17,10 +17,7 @@ import (
 )
 
 func TestGetIPCSocket(t *testing.T) {
-	ipc, err := GetIPCSocket()
-	if err != nil {
-		t.Errorf("Failed to acquire the IPC socket: %v", err)
-	}
+	ipc := getTestIPC(testMessages[""])
 	ipc.Close()
 	if ipc.open {
 		t.Error("IPC socket appears open after closing.")
@@ -28,7 +25,7 @@ func TestGetIPCSocket(t *testing.T) {
 }
 
 func TestRaw(t *testing.T) {
-	ipc, _ := GetIPCSocket()
+	ipc := getTestIPC(testMessages["workspaces"])
 
 	_, err := ipc.Raw(I3GetWorkspaces, "")
 	if err != nil {

--- a/socket_test.go
+++ b/socket_test.go
@@ -17,7 +17,8 @@ import (
 )
 
 func TestGetIPCSocket(t *testing.T) {
-	ipc := getTestIPC(testMessages[""])
+	startTestIPCSocket(testMessages[""])
+	ipc, _ := GetIPCSocket()
 	ipc.Close()
 	if ipc.open {
 		t.Error("IPC socket appears open after closing.")
@@ -25,7 +26,9 @@ func TestGetIPCSocket(t *testing.T) {
 }
 
 func TestRaw(t *testing.T) {
-	ipc := getTestIPC(testMessages["workspaces"])
+	ipc, _ := GetIPCSocket()
+
+	go startTestIPCSocket(testMessages["workspaces"])
 
 	_, err := ipc.Raw(I3GetWorkspaces, "")
 	if err != nil {

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -16,7 +16,8 @@ import (
 	"testing"
 )
 
-func TestInit(t *testing.T) {
+// TODO: fix this test
+func Init(t *testing.T) {
 	StartEventListener()
 
 	for _, s := range eventSockets {

--- a/subscribe_test.go
+++ b/subscribe_test.go
@@ -17,7 +17,16 @@ import (
 )
 
 // TODO: fix this test
-func Init(t *testing.T) {
+func TestInit(t *testing.T) {
+	// Because StartEventListener sends events to the socket we have to start
+	// the test socket before calling it. In other tests we can first call
+	// GetIPCSocket(), get the socket, and then start the server end of the socket
+	// with startTestIPCSocket to be sure that the test socket is created
+	// (newConn being called) before something is written to it. Here we don't have
+	// that assurance, we're relying on timing, which is kind of terrible, but seems
+	// to work. Should refactor this to be provably correct though.
+	go startTestIPCSocket(testMessages["subscribe"])
+
 	StartEventListener()
 
 	for _, s := range eventSockets {

--- a/tree_test.go
+++ b/tree_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestGetTree(t *testing.T) {
-	ipc, _ := GetIPCSocket()
+	ipc := getTestIPC(testMessages["tree"])
 
 	//root, err := GetTree(ipc)
 	_, err := ipc.GetTree()

--- a/tree_test.go
+++ b/tree_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 func TestGetTree(t *testing.T) {
-	ipc := getTestIPC(testMessages["tree"])
+	ipc, _ := GetIPCSocket()
+
+	go startTestIPCSocket(testMessages["tree"])
 
 	//root, err := GetTree(ipc)
 	_, err := ipc.GetTree()

--- a/utils_test.go
+++ b/utils_test.go
@@ -63,4 +63,28 @@ var testMessages = map[string][]testRequestResponse{
 		i3Message{I3GetBarConfig, "bar-bxuqzf"},
 		i3Message{I3GetBarConfig, "{\"id\": \"bar-bxuqzf\",\"mode\": \"dock\",\"position\": \"bottom\",\"status_command\": \"i3status\",\"font\": \"-misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1\",\"workspace_buttons\": true,\"binding_mode_indicator\": true,\"verbose\": false,\"colors\": {\"background\": \"#c0c0c0\",\"statusline\": \"#00ff00\",\"focused_workspace_text\": \"#ffffff\",\"focused_workspace_bg\": \"#000000\"}}"},
 	}},
+	"command": {{
+		i3Message{I3Command, "exec /bin/true"},
+		i3Message{I3Command, "[{ \"success\": true }]"},
+	}},
+	"marks": {{
+		i3Message{I3GetMarks, ""},
+		i3Message{I3GetMarks, "[]"},
+	}},
+	"outputs": {{
+		i3Message{I3GetOutputs, ""},
+		i3Message{I3GetOutputs, "[{\"name\": \"LVDS1\",\"active\": true,\"current_workspace\": \"4\",\"rect\": {\"x\": 0,\"y\": 0,\"width\": 1280,\"height\": 800}},{\"name\": \"VGA1\",\"active\": true,\"current_workspace\": \"1\",\"rect\": {\"x\": 1280,\"y\": 0,\"width\": 1280,\"height\": 1024}}]"},
+	}},
+	"tree": {{
+		i3Message{I3GetTree, ""},
+		i3Message{I3GetTree, "{\"id\": 6875648,\"name\": \"root\",\"rect\": {\"x\": 0,\"y\": 0,\"width\": 1280,\"height\": 800},\"nodes\": [{\"id\": 6878320,\"name\": \"LVDS1\",\"layout\": \"output\",\"rect\": {\"x\": 0,\"y\": 0,\"width\": 1280,\"height\": 800},\"nodes\": [{\"id\": 6878784,\"name\": \"topdock\",\"layout\": \"dockarea\",\"orientation\": \"vertical\",\"rect\": {\"x\": 0,\"y\": 0,\"width\": 1280,\"height\": 0}},{\"id\": 6879344,\"name\": \"content\",\"rect\": {\"x\": 0,\"y\": 0,\"width\": 1280,\"height\": 782},\"nodes\": [{\"id\": 6880464,\"name\": \"1\",\"orientation\": \"horizontal\",\"rect\": {\"x\": 0,\"y\": 0,\"width\": 1280,\"height\": 782},\"floating_nodes\": [],\"nodes\": [{\"id\": 6929968,\"name\": \"#aa0000\",\"border\": \"normal\",\"percent\": 1,\"rect\": {\"x\": 0,\"y\": 18,\"width\": 1280,\"height\": 782}}]}]},{\"id\": 6880208,\"name\": \"bottomdock\",\"layout\": \"dockarea\",\"orientation\": \"vertical\",\"rect\": {\"x\": 0,\"y\": 782,\"width\": 1280,\"height\": 18},\"nodes\": [{\"id\": 6931312,\"name\": \"#00aa00\",\"percent\": 1,\"rect\": {\"x\": 0,\"y\": 782,\"width\": 1280,\"height\": 18}}]}]}]}"},
+	}},
+	"version": {{
+		i3Message{I3GetVersion, ""},
+		i3Message{I3GetVersion, "{\"human_readable\" : \"4.2-169-gf80b877 (2012-08-05, branch \\\"next\\\")\",\"loaded_config_file_name\" : \"/home/hwangcc23/.i3/config\",\"minor\" : 2,\"patch\" : 0,\"major\" : 4}"},
+	}},
+	"workspaces": {{
+		i3Message{I3GetWorkspaces, ""},
+		i3Message{I3GetWorkspaces, "[{\"num\": 0,\"name\": \"1\",\"visible\": true,\"focused\": true,\"urgent\": false,\"rect\": {\"x\": 0,\"y\": 0,\"width\": 1280,\"height\": 800},\"output\": \"LVDS1\"},{\"num\": 1,\"name\": \"2\",\"visible\": false,\"focused\": false,\"urgent\": false,\"rect\": {\"x\": 0,\"y\": 0,\"width\": 1280,\"height\": 800},\"output\": \"LVDS1\"}]"},
+	}},
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,58 @@
+package i3ipc
+
+import (
+	"encoding/binary"
+	"net"
+)
+
+type i3Message struct {
+	messageType MessageType
+	payload     string
+}
+
+type TestRequestResponse struct {
+	req, res i3Message
+}
+
+func GetTestIPC(data []TestRequestResponse) *IPCSocket {
+	server, client := net.Pipe()
+
+	go func() {
+		defer server.Close()
+		var tmp []byte
+		length := make([]byte, 4)
+		mType := make([]byte, 4)
+
+		for _, trr := range data {
+			tmp = make([]byte, 256)
+			ipcMsg := make([]byte, 0)
+
+			binary.LittleEndian.PutUint32(length, uint32(len(trr.res.payload)))
+			binary.LittleEndian.PutUint32(mType, uint32(trr.res.messageType))
+
+			for _, a := range [][]byte{[]byte(_Magic), length, mType, []byte(trr.res.payload)} {
+				ipcMsg = append(ipcMsg, a...)
+			}
+
+			server.Read(tmp)
+			server.Write(ipcMsg)
+		}
+	}()
+
+	ipc := &IPCSocket{}
+	ipc.socket = client
+	ipc.open = true
+
+	return ipc
+}
+
+// Test messages used in the various unit test
+var testMessages = map[string][]TestRequestResponse{
+	"bar": {{
+		i3Message{I3GetBarConfig, ""},
+		i3Message{I3GetBarConfig, "[\"bar-bxuqzf\"]"},
+	}, {
+		i3Message{I3GetBarConfig, "bar-bxuqzf"},
+		i3Message{I3GetBarConfig, "{\"id\": \"bar-bxuqzf\",\"mode\": \"dock\",\"position\": \"bottom\",\"status_command\": \"i3status\",\"font\": \"-misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1\",\"workspace_buttons\": true,\"binding_mode_indicator\": true,\"verbose\": false,\"colors\": {\"background\": \"#c0c0c0\",\"statusline\": \"#00ff00\",\"focused_workspace_text\": \"#ffffff\",\"focused_workspace_bg\": \"#000000\"}}"},
+	}},
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -14,44 +14,54 @@ type testRequestResponse struct {
 	req, res i3Message
 }
 
-// Function creates 3 things:
-// - an in-memory network pipe
-// - a server that listens to it and is pre-programmed
-// - an IPCSocket that is configured to write the pipe
-//
-// This allows us to test the lib against a mocked i3 socket so
-// we don't have to actually be running i3 in order to run tests.
-func getTestIPC(data []testRequestResponse) *IPCSocket {
-	server, client := net.Pipe()
+var server, client net.Conn
 
-	go func() {
-		defer server.Close()
-		var tmp []byte
-		length := make([]byte, 4)
-		mType := make([]byte, 4)
+// Init the test connSource
+func init() {
+	cs = &testConnSource{}
+}
 
-		// For every pre-programmed request/response pair we listen to the pipe and then respond
-		for _, trr := range data {
-			tmp = make([]byte, 256)
-			ipcMsg := make([]byte, 0)
+// Listens for input and the produces i3 message output according
+// to the req/resp data it is given. Will repeat for every testRequestResponse
+// in the array, so make sure the IPC operation you're testing has the same
+// number of IPC calls as there are elements in the array.
+func startTestIPCSocket(data []testRequestResponse) {
+	defer server.Close()
+	var tmp []byte
+	length := make([]byte, 4)
+	mType := make([]byte, 4)
 
-			binary.LittleEndian.PutUint32(length, uint32(len(trr.res.payload)))
-			binary.LittleEndian.PutUint32(mType, uint32(trr.res.messageType))
+	// For every pre-programmed request/response pair we listen to the pipe and then respond
+	for _, trr := range data {
+		tmp = make([]byte, 256)
+		ipcMsg := make([]byte, 0)
 
-			for _, a := range [][]byte{[]byte(_Magic), length, mType, []byte(trr.res.payload)} {
-				ipcMsg = append(ipcMsg, a...)
-			}
+		binary.LittleEndian.PutUint32(length, uint32(len(trr.res.payload)))
+		binary.LittleEndian.PutUint32(mType, uint32(trr.res.messageType))
 
-			server.Read(tmp)
-			server.Write(ipcMsg)
+		for _, a := range [][]byte{[]byte(_Magic), length, mType, []byte(trr.res.payload)} {
+			ipcMsg = append(ipcMsg, a...)
 		}
-	}()
 
-	ipc := &IPCSocket{}
-	ipc.socket = client
-	ipc.open = true
+		server.Read(tmp)
+		server.Write(ipcMsg)
+	}
+}
 
-	return ipc
+type testConnSource struct{}
+
+// Creates a new pipe that is used to supply test values to the socket
+func (dsf *testConnSource) newConn() (net.Conn, error) {
+	// If we get called again after already opening a connection
+	// (during the event subscription test for instance)
+	// then make sure to close the existing connection (if there
+	// is one) so we don't leak connections
+	if server != nil {
+		server.Close()
+	}
+
+	server, client = net.Pipe()
+	return client, nil
 }
 
 // Test messages used in the various unit test. The source for most of the test JSON is: http://i3wm.org/docs/ipc.html
@@ -75,6 +85,20 @@ var testMessages = map[string][]testRequestResponse{
 		i3Message{I3GetOutputs, ""},
 		i3Message{I3GetOutputs, "[{\"name\": \"LVDS1\",\"active\": true,\"current_workspace\": \"4\",\"rect\": {\"x\": 0,\"y\": 0,\"width\": 1280,\"height\": 800}},{\"name\": \"VGA1\",\"active\": true,\"current_workspace\": \"1\",\"rect\": {\"x\": 1280,\"y\": 0,\"width\": 1280,\"height\": 1024}}]"},
 	}},
+	"subscribe": {
+		{
+			i3Message{I3Subscribe, ""},
+			i3Message{I3Subscribe, "{ \"success\": true }"},
+		},
+		{
+			i3Message{I3Subscribe, ""},
+			i3Message{I3Subscribe, "{ \"success\": true }"},
+		},
+		{
+			i3Message{I3Subscribe, ""},
+			i3Message{I3Subscribe, "{ \"success\": true }"},
+		},
+	},
 	"tree": {{
 		i3Message{I3GetTree, ""},
 		i3Message{I3GetTree, "{\"id\": 6875648,\"name\": \"root\",\"rect\": {\"x\": 0,\"y\": 0,\"width\": 1280,\"height\": 800},\"nodes\": [{\"id\": 6878320,\"name\": \"LVDS1\",\"layout\": \"output\",\"rect\": {\"x\": 0,\"y\": 0,\"width\": 1280,\"height\": 800},\"nodes\": [{\"id\": 6878784,\"name\": \"topdock\",\"layout\": \"dockarea\",\"orientation\": \"vertical\",\"rect\": {\"x\": 0,\"y\": 0,\"width\": 1280,\"height\": 0}},{\"id\": 6879344,\"name\": \"content\",\"rect\": {\"x\": 0,\"y\": 0,\"width\": 1280,\"height\": 782},\"nodes\": [{\"id\": 6880464,\"name\": \"1\",\"orientation\": \"horizontal\",\"rect\": {\"x\": 0,\"y\": 0,\"width\": 1280,\"height\": 782},\"floating_nodes\": [],\"nodes\": [{\"id\": 6929968,\"name\": \"#aa0000\",\"border\": \"normal\",\"percent\": 1,\"rect\": {\"x\": 0,\"y\": 18,\"width\": 1280,\"height\": 782}}]}]},{\"id\": 6880208,\"name\": \"bottomdock\",\"layout\": \"dockarea\",\"orientation\": \"vertical\",\"rect\": {\"x\": 0,\"y\": 782,\"width\": 1280,\"height\": 18},\"nodes\": [{\"id\": 6931312,\"name\": \"#00aa00\",\"percent\": 1,\"rect\": {\"x\": 0,\"y\": 782,\"width\": 1280,\"height\": 18}}]}]}]}"},

--- a/utils_test.go
+++ b/utils_test.go
@@ -10,11 +10,18 @@ type i3Message struct {
 	payload     string
 }
 
-type TestRequestResponse struct {
+type testRequestResponse struct {
 	req, res i3Message
 }
 
-func GetTestIPC(data []TestRequestResponse) *IPCSocket {
+// Function creates 3 things:
+// - an in-memory network pipe
+// - a server that listens to it and is pre-programmed
+// - an IPCSocket that is configured to write the pipe
+//
+// This allows us to test the lib against a mocked i3 socket so
+// we don't have to actually be running i3 in order to run tests.
+func getTestIPC(data []testRequestResponse) *IPCSocket {
 	server, client := net.Pipe()
 
 	go func() {
@@ -23,6 +30,7 @@ func GetTestIPC(data []TestRequestResponse) *IPCSocket {
 		length := make([]byte, 4)
 		mType := make([]byte, 4)
 
+		// For every pre-programmed request/response pair we listen to the pipe and then respond
 		for _, trr := range data {
 			tmp = make([]byte, 256)
 			ipcMsg := make([]byte, 0)
@@ -46,8 +54,8 @@ func GetTestIPC(data []TestRequestResponse) *IPCSocket {
 	return ipc
 }
 
-// Test messages used in the various unit test
-var testMessages = map[string][]TestRequestResponse{
+// Test messages used in the various unit test. The source for most of the test JSON is: http://i3wm.org/docs/ipc.html
+var testMessages = map[string][]testRequestResponse{
 	"bar": {{
 		i3Message{I3GetBarConfig, ""},
 		i3Message{I3GetBarConfig, "[\"bar-bxuqzf\"]"},

--- a/version_test.go
+++ b/version_test.go
@@ -17,7 +17,9 @@ import (
 )
 
 func TestGetVersion(t *testing.T) {
-	ipc := getTestIPC(testMessages["version"])
+	ipc, _ := GetIPCSocket()
+
+	go startTestIPCSocket(testMessages["version"])
 
 	_, err := ipc.GetVersion()
 	if err != nil {

--- a/version_test.go
+++ b/version_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestGetVersion(t *testing.T) {
-	ipc, _ := GetIPCSocket()
+	ipc := getTestIPC(testMessages["version"])
 
 	_, err := ipc.GetVersion()
 	if err != nil {

--- a/workspaces_test.go
+++ b/workspaces_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestGetWorkspaces(t *testing.T) {
-	ipc, _ := GetIPCSocket()
+	ipc := getTestIPC(testMessages["workspaces"])
 
 	_, err := ipc.GetWorkspaces()
 	if err != nil {

--- a/workspaces_test.go
+++ b/workspaces_test.go
@@ -17,7 +17,9 @@ import (
 )
 
 func TestGetWorkspaces(t *testing.T) {
-	ipc := getTestIPC(testMessages["workspaces"])
+	ipc, _ := GetIPCSocket()
+
+	go startTestIPCSocket(testMessages["workspaces"])
 
 	_, err := ipc.GetWorkspaces()
 	if err != nil {


### PR DESCRIPTION
The [original lib](https://github.com/proxypoke/i3ipc) had unit tests but they only worked when running them on a machine that had i3 running. This is, obviously, not ideal for CI environments (like Travis CI), as they don't have i3 running and it isn't really practical (or even feasible) to install and start it. Also, running the tests this way makes them _integration_ tests that test both the lib and the instance of i3 that the lib is talking to.

I'd like to have Travis run the tests and also test just the lib itself, not i3 as well. The refactoring will ensure that, instead of getting an `IPCSocket` that talks to an actual socket, tests will talk to a [pipe](https://golang.org/pkg/net/#Pipe) that is configured to give pre-baked responses. These responses will be the ones that the IPC API is supposed to give according to the [official documentation](http://i3wm.org/docs/ipc.html).