### PR TITLE
Change I3Node.ID to a int64

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -19,7 +19,8 @@ import (
 // I3Node represents a Node in the i3 tree. For documentation of the fields,
 // refer to http://i3wm.org/docs/ipc.html#_tree_reply.
 type I3Node struct {
-	ID                 int32
+	//int32 isn't large enough to hold all the ids
+	ID                 int64
 	Name               string
 	Type               string
 	Border             string


### PR DESCRIPTION
I've run into an Unmarshal Error on the I3Node.ID field as the Value it tried to store was larger than an int32.

This commit increases the field to an int64.

This will break existing programs but it is better than to fatal out during an Unmarshal call